### PR TITLE
Expose doExecutePowershell, fixed example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var password = 'password';
 var _host = '10.xxx.xxx.xxx';
 var _port = 5985;
 
-var auth = 'Basic' + Buffer.from(userName + ":" + password, 'utf8').toString('base64');
+var auth = 'Basic ' + Buffer.from(userName + ":" + password, 'utf8').toString('base64');
 var params = {
     host: _host,
     port: _port,
@@ -68,7 +68,7 @@ params['auth'] = auth;
 params['shellId']= await winrm.shell.doCreateShell(params);
 
 // Execute Command1
-params['command'] = 'ipaddress /all';
+params['command'] = 'ipconfig /all';
 params['commandId'] = await winrm.command.doExecuteCommand(params);
 var result1= await winrm.command.doReceiveOutput(params);
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
     command: command
 };
 
-module.exports.runCommand = async function (_command, _host, _username, _password, _port) {
+module.exports.runCommand = async function (_command, _host, _username, _password, _port, _usePowershell = false) {
     try {
         var auth = 'Basic ' + Buffer.from(_username + ':' + _password, 'utf8').toString('base64');
         var params = {
@@ -19,7 +19,12 @@ module.exports.runCommand = async function (_command, _host, _username, _passwor
         params['shellId'] = shellId;
     
         params['command'] = _command;
-        var commandId = await command.doExecuteCommand(params);
+        var commandId
+        if ( _usePowershell ) {
+            commandId = await command.doExecutePowershell(params);
+        } else {
+            commandId = await command.doExecuteCommand(params);
+        }
     
         params['commandId'] = commandId;
         var output = await command.doReceiveOutput(params);
@@ -34,3 +39,6 @@ module.exports.runCommand = async function (_command, _host, _username, _passwor
    
 };
 
+module.exports.runPowershell = async function (_command, _host, _username, _password, _port) {
+  return module.exports.runCommand(_command, _host, _username, _password, _port, true);
+}

--- a/src/command.js
+++ b/src/command.js
@@ -82,7 +82,7 @@ function generatePowershellCommand(_params) {
 
 module.exports.doExecutePowershell = async function (_params) {
     _params['command'] = generatePowershellCommand(_params);
-    this.doExecuteCommand(_params);
+    return this.doExecuteCommand(_params);
 };
 
 module.exports.doReceiveOutput = async function (_params) {

--- a/src/command.js
+++ b/src/command.js
@@ -98,10 +98,10 @@ module.exports.doReceiveOutput = async function (_params) {
         if (result['s:Envelope']['s:Body'][0]['rsp:ReceiveResponse'][0]['rsp:Stream']) {
             for (let stream of result['s:Envelope']['s:Body'][0]['rsp:ReceiveResponse'][0]['rsp:Stream']) {
                 if (stream['$'].Name == 'stdout' && !stream['$'].hasOwnProperty('End')) {
-                    successOutput += new Buffer(stream['_'], 'base64').toString('ascii');
+                    successOutput += Buffer.from(stream['_'], 'base64').toString('ascii');
                 }
                 if (stream['$'].Name == 'stderr' && !stream['$'].hasOwnProperty('End')) {
-                    failedOutput += new Buffer(stream['_'], 'base64').toString('ascii');
+                    failedOutput += Buffer.from(stream['_'], 'base64').toString('ascii');
                 }
             }
         }


### PR DESCRIPTION
- Expose doExecutePowershell as runPowershell
- Fixed missing return value in doExecutePowershell
- Fixed example in README.md
- Replaced deprecated `new Buffer`